### PR TITLE
Pod::Man: Mark man page references and functions in bold

### DIFF
--- a/TODO
+++ b/TODO
@@ -21,9 +21,6 @@ any of the following are very much welcome.
 
  * Escape all hyphens in the text of L<some-command> links.
 
- * Linux man page style now says foo(3) should be in .BR format, not .IR
-   as Pod::Man currently renders it.
-
  * Add a =for license stanza that takes license text and embeds it as a
    *roff comment.
 

--- a/lib/Pod/Man.pm
+++ b/lib/Pod/Man.pm
@@ -535,8 +535,8 @@ sub guesswork {
     # strings inserted around things that we've made small-caps if later
     # transforms should work on those strings.
 
-    # Italicize functions in the form func(), including functions that are in
-    # all capitals, but don't italize if there's anything between the parens.
+    # Embolden functions in the form func(), including functions that are in
+    # all capitals, but don't embolden if there's anything between the parens.
     # The function must start with an alphabetic character or underscore and
     # then consist of word characters or colons.
     if ($$self{MAGIC_FUNC}) {
@@ -544,11 +544,11 @@ sub guesswork {
             ( \b | \\s-1 )
             ( [A-Za-z_] ([:\w] | \\s-?[01])+ \(\) )
         } {
-            $1 . '\f(IS' . $2 . '\f(IE'
+            $1 . '\f(BS' . $2 . '\f(BE'
         }egx;
     }
 
-    # Change references to manual pages to put the page name in italics but
+    # Change references to manual pages to put the page name in bold but
     # the number in the regular font, with a thin space between the name and
     # the number.  Only recognize func(n) where func starts with an alphabetic
     # character or underscore and contains only word characters, periods (for
@@ -562,7 +562,7 @@ sub guesswork {
             ( [A-Za-z_] (?:[.:\w] | \\- | \\s-?[01])+ )
             ( \( \d [a-z]* \) )
         } {
-            $1 . '\f(IS' . $2 . '\f(IE\|' . $3
+            $1 . '\f(BS' . $2 . '\f(BE\|' . $3
         }egx;
     }
 

--- a/t/data/basic.man
+++ b/t/data/basic.man
@@ -221,7 +221,7 @@ Dont forget \f(CW\*(C`$self\->method()\->{FIELDNAME} = {FOO=>BAR}\*(C'\fR.
 And make sure that \f(CW0\fR works too!
 .PP
 Now, if I use << or >> as my delimiters, then I have to use whitespace.
-So things like \f(CW\*(C`<$self\-\*(C'\fR\fImethod()\fR>> and \f(CW\*(C`<$self\-\*(C'\fR{\s-1FIELDNAME\s0}>> wont end
+So things like \f(CW\*(C`<$self\-\*(C'\fR\fBmethod()\fR>> and \f(CW\*(C`<$self\-\*(C'\fR{\s-1FIELDNAME\s0}>> wont end
 up doing what you might expect since the first > will still terminate
 the first < seen.
 .PP


### PR DESCRIPTION
As discussed recently, I took a stab at this, as this one seemed easy. Here's a patch. :)