### PR TITLE
Make errors=none suppress the errata section

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,11 @@ podlators 4.11 (unreleased)
     information when COLUMNS isn't set, instead of getting a string value
     that later cannot be used numerically.
 
+    Specifying 'none' for the errors option of Pod::Man and Pod::Text no
+    longer results in an errata section in the generated documentation,
+    which better matches the documented behaviour that '"none" ignores POD
+    errors entirely, as much as possible.'
+
     Fix order of SEE ALSO section in manual pages to match the
     recommendation of perlpodstyle.
 

--- a/lib/Pod/Man.pm
+++ b/lib/Pod/Man.pm
@@ -129,6 +129,7 @@ sub new {
         $self->no_errata_section (0);
         $self->complain_stderr (0);
     } elsif ($$self{errors} eq 'none') {
+        $self->no_errata_section (0);
         $self->no_whining (1);
     } else {
         croak (qq(Invalid errors setting: "$$self{errors}"));

--- a/lib/Pod/Text.pm
+++ b/lib/Pod/Text.pm
@@ -117,6 +117,7 @@ sub new {
         $self->no_errata_section (0);
         $self->complain_stderr (0);
     } elsif ($$self{opt_errors} eq 'none') {
+        $self->no_errata_section (0);
         $self->no_whining (1);
     } else {
         croak (qq(Invalid errors setting: "$$self{errors}"));


### PR DESCRIPTION
Specifying 'none' for the errors option of Pod::Man and Pod::Text no
longer results in an errata section in the generated documentation,
which better matches the documented behaviour that '"none" ignores POD
errors entirely, as much as possible.'