### PR TITLE
Stop using $running_under_some_shell

### DIFF
--- a/scripts/pod2man.PL
+++ b/scripts/pod2man.PL
@@ -38,7 +38,7 @@ print "Extracting $file (with variable substitutions)\n";
 print {$out} <<"PREAMBLE" or die "Cannot write to $file: $!\n";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-        if \$running_under_some_shell;
+        if 0; # ^ Run only under a shell
 PREAMBLE
 
 # In the following, Perl variables are not expanded during extraction.

--- a/scripts/pod2text.PL
+++ b/scripts/pod2text.PL
@@ -38,7 +38,7 @@ print "Extracting $file (with variable substitutions)\n";
 print {$out} <<"PREAMBLE" or die "Cannot write to $file: $!\n";
 $Config{startperl}
     eval 'exec $Config{perlpath} -S \$0 \${1+"\$@"}'
-        if \$running_under_some_shell;
+        if 0; # ^ Run only under a shell
 PREAMBLE
 
 # In the following, Perl variables are not expanded during extraction.


### PR DESCRIPTION
Using an unset variable hides the true intent and
also requires an extra backslash `\$running_under_some_shell`
when used in heredoc.

Use '0', with a comment making clear the goal of 'if 0'
in that magic shebang incantation to fallback to bash
when needed.