### PR TITLE
Fixes for podlators for z/OS and for generic EBCDIC

### DIFF
--- a/t/general/basic.t
+++ b/t/general/basic.t
@@ -80,9 +80,8 @@ for my $module (sort keys %OUTPUT) {
         $got =~ s{ \A .* \n [.]nh \n }{}xms;
     }
 
-    # OS/390 is EBCDIC, which apparently uses a different character for ESC.
-    # Try to convert so that the test still works.
-    if ($^O eq 'os390' && $module eq 'Pod::Text::Termcap') {
+    # Try to convert on EBCDIC boxes so that the test still works.
+    if (ord "A" == 193 && $module eq 'Pod::Text::Termcap') {
         $got =~ tr{\033}{\047};
     }
 

--- a/t/man/empty.t
+++ b/t/man/empty.t
@@ -32,7 +32,8 @@ local $SIG{__WARN__} = sub { croak($_[0]) };
 # Try a POD document where the only command is invalid.  Make sure it succeeds
 # and doesn't throw an exception.
 ## no critic (ValuesAndExpressions::ProhibitEscapedCharacters)
-ok(eval { $parser->parse_string_document("=\xa0") },
+my $invalid_char = chr utf8::unicode_to_native(0xa0);
+ok(eval { $parser->parse_string_document("=$invalid_char") },
     'Parsed invalid document');
 is($@, q{}, '...with no errors');
 ## use critic

--- a/t/man/no-encode.t
+++ b/t/man/no-encode.t
@@ -38,14 +38,18 @@ BEGIN {
 
 # Ensure we don't get warnings by throwing an exception if we see any.  This
 # is overridden below when we enable utf8 and do expect a warning.
-local $SIG{__WARN__} = sub { die "No warnings expected\n" };
-
+local $SIG{__WARN__} = sub { die join("\n",
+                                      "No warnings expected; instead got:",
+                                      @_);
+                           };
 # First, check that everything works properly when utf8 isn't set.  We expect
 # to get accent-mangled ASCII output.  Don't use Test::Podlators, since it
 # wants to import Encode.
 #
 ## no critic (ValuesAndExpressions::ProhibitEscapedCharacters)
-my $pod = "=encoding latin1\n\n=head1 NAME\n\nBeyonc\xE9!";
+my $pod = "=encoding latin1\n\n=head1 NAME\n\nBeyonc"
+        . chr(utf8::unicode_to_native(0xE9))
+        . "!";
 my $parser = Pod::Man->new(utf8 => 0, name => 'test');
 my $output;
 $parser->output_string(\$output);

--- a/t/text/invalid.t
+++ b/t/text/invalid.t
@@ -55,7 +55,8 @@ sub check_document {
 
 # Document whose only content is an invalid command.
 ## no critic (ValuesAndExpressions::ProhibitEscapedCharacters)
-check_document("=\xa0", 'invalid command');
+my $invalid_char = chr utf8::unicode_to_native(0xa0);
+check_document("=$invalid_char", 'invalid command');
 
 # Document containing only a =cut.
 check_document('=cut', 'document with only =cut');


### PR DESCRIPTION
It turns out that z/OS can operate in both ASCII and EBCDIC mode.  Previously it was assumed by Perl to be EBCDIC-only.  Some IBMers contributed code later in the Perl 5.35 development cycle to get the ASCII version working.  podlators is one of the few modules that also made this assumption. about z/OS.   Recently, I became aware of this issue, and so I customized the podlators shipped with the Perl core to include the first commit in this P.R, as I didn't  think there was enough time to get a new release of podlators out before the 5.36 code freeze, and it wouldn't be fair to you to ask for such a quick turn-around.

podlators still doesn't fully work on EBCDIC; the core test suite skips its tests.  Part of that is Pod::Simple, which needs fixes first.  But in auditing the code some time ago, I found some areas that made assumptions that the character set is ASCII.  I've been waiting to get all of podlators working before submitting a patch to you with these minor things.  But since the podlators version we ship already needed to be customized, I threw those in too.

The bottom line is that, unless things get reverted for some reason, the podlators shipped with v5.36 Perl will contain these two patches.

The character set translation code in the second patch is completely optimized out on an ASCII machine, so there is no performance penalty for it.

When testing these patches on z/OS, I needed more info as to what is failing, so extra information about the failure is output in encode.t