### PR TITLE
Pass tests with NO_COLOR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@
 /podlators-*.tar.gz.asc
 /scripts/pod2man
 /scripts/pod2text
+/t/tmp/
+
+# Some plenv/carton cruft
+.perl-version
+cpanfile.snapshot
+/local/
 
 # Not needed in the stand-alone podlators package, but necessary when
 # included in Perl core.

--- a/t/docs/spdx-license.t
+++ b/t/docs/spdx-license.t
@@ -56,6 +56,7 @@ my @IGNORE = (
     qr{ \A (MY)? META [.] .* }xms,          # Generated file, no license itself
     qr{ [.] output \z }xms,                 # Test data
     qr{ pod2htm . [.] tmp \z }xms,          # Windows pod2html output
+    qr{ cpanfile\.snapshot }xms,            # Carton snapshot
     qr{ ~ \z }xms,                          # Backup files
 );
 my @IGNORE_PATHS = (
@@ -66,12 +67,14 @@ my @IGNORE_PATHS = (
     qr{ \A [.] /cover_db/ }xms,             # Artifacts from coverage testing
     qr{ \A [.] /debian/ }xms,               # Found in debian/* branches
     qr{ \A [.] /docs/metadata/ }xms,        # Package license should be fine
+    qr{ \A [.] /local/ }xms,                # Carton local lib
     qr{ \A [.] /README ( [.] .* )? \z }xms, # Package license should be fine
     qr{ \A [.] /share/ }xms,                # Package license should be fine
     qr{ \A [.] /t/data/generate/ }xms,      # Test metadata
     qr{ \A [.] /t/data/spin/ }xms,          # Test metadata
     qr{ \A [.] /t/data/update/ }xms,        # Test output
     qr{ \A [.] /t/data .* [.] json \z }xms, # Test metadata
+    qr{ \A [.] /t/tmp }xms,                 # Test metadata
 );
 #>>>
 ## use critic

--- a/t/general/basic.t
+++ b/t/general/basic.t
@@ -30,6 +30,9 @@ use File::Spec;
 use Test::More tests => 15;
 use Test::Podlators qw(slurp);
 
+# Color is expected to be enabled in tests
+BEGIN { delete $ENV{NO_COLOR}; }
+
 # Check that all the modules can be loaded.
 BEGIN {
     use_ok('Pod::Man');

--- a/t/style/strict.t
+++ b/t/style/strict.t
@@ -48,7 +48,7 @@ skip_unless_automated('Strictness tests');
 use_prereq('Test::Strict', '0.25');
 
 # Directories to exclude from checks.
-my %EXCLUDE = map { $_ => 1 } qw(.git blib);
+my %EXCLUDE = map { $_ => 1 } qw(.git blib local);
 
 # Determine whether we want to check the given file or top-level directory.
 # Assume that the only interesting files at the top level are directories or

--- a/t/text/color.t
+++ b/t/text/color.t
@@ -17,6 +17,9 @@ use lib 't/lib';
 use Test::More tests => 11;
 use Test::Podlators qw(test_snippet);
 
+# Color is expected to be enabled in tests
+BEGIN { delete $ENV{NO_COLOR}; }
+
 # Load the module.
 BEGIN {
     use_ok('Pod::Text::Color');


### PR DESCRIPTION
The first commit just made tests pass after I picked a plenv perl that had carton available to be able to install some of the dependencies needed for the AUTHOR_TESTS.  There were some author tests that didn't pass, but I might have done something wrong as it was checking spelling in `blib` and I am not sure why.  

In any case, the second commit is the important one.  It allows tests to pass for folks who have [`NO_COLOR` set to a value in their environment](https://metacpan.org/pod/Term::ANSIColor#NO_COLOR).  It seemed best to remove it, instead of skipping tests, but the other is also an option.