### PR TITLE
Unconditionally style contents of `L<>` tags

### DIFF
--- a/t/data/snippets/man/nonbreaking-space-l
+++ b/t/data/snippets/man/nonbreaking-space-l
@@ -20,7 +20,7 @@ S<L<RFC4034|https://tools.ietf.org/html/rfc4034>>
 S<> wrapping L<> should make the space between the anchor and URL
 non-breaking and thus keep them together.
 .PP
-perl Net::DNS Net::DNS::RR Net::DNS::SEC
+\&\fBperl\fR \fBNet::DNS\fR \fBNet::DNS::RR\fR \fBNet::DNS::SEC\fR
 RFC2535\ <https://tools.ietf.org/html/rfc2535>
 RFC2536\ <https://tools.ietf.org/html/rfc2536>
 RFC2931\ <https://tools.ietf.org/html/rfc2931>


### PR DESCRIPTION
This lets users properly highlight man(1) references even if guesswork doesn't report it as a manref. The offending links looked something like this:

`@@RXVT_NAME@@perl(3)`

Being able to wrap these in `L<>` to bold the entire string is a nicety.

A (too) thorough writeup, exploration, & justification of this PR can be found [here](https://sirabella.org/blog/rabbitholes)

TODO:
- [ ] fix tests
- [ ] add another test outlining specific functionality
- [ ] find a better way to apply bold than manual format codes?