### PR TITLE
Restrict use autodie 20240712

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
                       Revision history for podlators
 
+v6.0.99 - 2024-07-12
+
+ - Restrict use of 'use autodie' in files touched by Perl 5 build process.
+
 v6.0.0 - 2024-07-10
 
  - Drop support for Perl 5.10.  podlators now requires Perl 5.12 or later.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,6 @@
 # SPDX-License-Identifier: GPL-1.0-or-later OR Artistic-1.0-Perl
 
 use 5.012;
-use autodie;
 use warnings;
 
 use Config;
@@ -27,15 +26,15 @@ use File::Spec;
 # Returns: Distribution version as a string
 sub dist_version {
     my ($path) = @_;
-    open(my $fh, '<', $path);
+    open(my $fh, '<', $path)
+        or die "$0: cannot open lib/Pod/Man.pm: $!\n";
     while (defined(my $line = <$fh>)) {
         if ($line =~ m{ \A package \s+ \S+ \s+ (v[\d.]+) }xms) {
-            close($fh);
+            close($fh) or die "$0: cannot close lib/Pod/Man.pm\n";
             return $1;
         }
     }
-    close($fh);
-    die "$0: cannot find version in lib/Pod/Man.pm\n";
+    close($fh) or die "$0: cannot close lib/Pod/Man.pm\n";
 }
 
 # Generate full paths for scripts distributed in the bin directory.  Appends

--- a/lib/Pod/Man.pm
+++ b/lib/Pod/Man.pm
@@ -12,7 +12,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Man v6.0.0;
+package Pod::Man v6.0.99;
 
 use 5.012;
 use parent qw(Pod::Simple);

--- a/lib/Pod/ParseLink.pm
+++ b/lib/Pod/ParseLink.pm
@@ -11,7 +11,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::ParseLink v6.0.0;
+package Pod::ParseLink v6.0.99;
 
 use 5.012;
 use warnings;

--- a/lib/Pod/Text.pm
+++ b/lib/Pod/Text.pm
@@ -12,7 +12,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Text v6.0.0;
+package Pod::Text v6.0.99;
 
 use 5.012;
 use parent qw(Pod::Simple);

--- a/lib/Pod/Text/Color.pm
+++ b/lib/Pod/Text/Color.pm
@@ -10,7 +10,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Text::Color v6.0.0;
+package Pod::Text::Color v6.0.99;
 
 use 5.012;
 use parent qw(Pod::Text);
@@ -173,7 +173,7 @@ Pod::Text::Color 2.01 was included in Perl 5.9.3, the first version of Perl to
 incorporate those changes.
 
 Several problems with wrapping and line length were fixed as recently as
-Pod::Text::Color 6.0.0.
+Pod::Text::Color 6.0.99.
 
 This module inherits its API and most behavior from Pod::Text, so the details
 in L<Pod::Text/COMPATIBILITY> also apply.  Pod::Text and Pod::Text::Color have

--- a/lib/Pod/Text/Overstrike.pm
+++ b/lib/Pod/Text/Overstrike.pm
@@ -17,7 +17,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Text::Overstrike v6.0.0;
+package Pod::Text::Overstrike v6.0.99;
 
 use 5.012;
 use parent qw(Pod::Text);
@@ -177,7 +177,7 @@ The current API based on L<Pod::Simple> was added in Pod::Text::Overstrike
 2.00, included in Perl 5.9.3.
 
 Several problems with wrapping and line length were fixed as recently as
-Pod::Text::Overstrike 6.0.0.
+Pod::Text::Overstrike 6.0.99.
 
 This module inherits its API and most behavior from Pod::Text, so the details
 in L<Pod::Text/COMPATIBILITY> also apply.  Pod::Text and Pod::Text::Overstrike

--- a/lib/Pod/Text/Termcap.pm
+++ b/lib/Pod/Text/Termcap.pm
@@ -10,7 +10,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Text::Termcap v6.0.0;
+package Pod::Text::Termcap v6.0.99;
 
 use 5.012;
 use parent qw(Pod::Text);
@@ -244,7 +244,7 @@ unformatted output for better results on dumb terminals.  The next version to
 be incorporated into Perl, 4.14, was included in Perl 5.31.8.
 
 Several problems with wrapping and line length were fixed as recently as
-Pod::Text::Termcap 6.0.0.
+Pod::Text::Termcap 6.0.99.
 
 This module inherits its API and most behavior from Pod::Text, so the details
 in L<Pod::Text/COMPATIBILITY> also apply.  Pod::Text and Pod::Text::Termcap

--- a/scripts/pod2man.PL
+++ b/scripts/pod2man.PL
@@ -5,7 +5,6 @@
 # Perl core.
 
 use 5.012;
-use autodie;
 use warnings;
 
 use Config qw(%Config);
@@ -20,14 +19,14 @@ use File::Basename qw(basename dirname);
 
 # This forces PL files to create target in same directory as PL file.
 # This is so that make depend always knows where to find PL derivatives.
-chdir(dirname($0));
+chdir(dirname($0)) or die "Cannot change directories: $!\n";
 my $file = basename($0, '.PL');
 if ($^O eq 'VMS') {
     $file .= '.com';
 }
 
 # Create the generated script.
-open(my $out, '>', $file);
+open(my $out, '>', $file) or die "Cannot create $file: $!\n";
 print "Extracting $file (with variable substitutions)\n"
   or die "$0: cannot write to stdout: $!\n";
 
@@ -560,8 +559,8 @@ Perl core distribution as of 5.6.0.
 SCRIPT_BODY
 
 # Finish the generation of the script.
-close($out);
-chmod(0755, $file);
+close($out) or die "Cannot close $file: $!\n";
+chmod(0755, $file) or die "Cannot reset permissions for $file: $!\n";
 if ($Config{'eunicefix'} ne q{:}) {
     exec("$Config{'eunicefix'} $file");
 }


### PR DESCRIPTION
For https://github.com/rra/podlators/issues/32.  As I didn't want to pre-empt your use of `v6.0.1`, I arbitrarily used `6.0.99` throughout.  Please replace as needed.  Also, the perl sync-with-cpan program now checks the Changes file to make sure there's an updated entry; please change the content I provided there as needed.  Thanks.